### PR TITLE
Use camelize, not classify when trying to find a driver class

### DIFF
--- a/lib/conduit/util.rb
+++ b/lib/conduit/util.rb
@@ -11,7 +11,7 @@ module Conduit
       Conduit::Driver.const_get(driver)
     rescue NameError => error
       message = "Unable to find driver with arguments: #{args.join ','}. " +
-        "Expected #{error.name} to be implemented"
+                "Expected #{error.name} to be implemented"
       raise NameError(message)
     end
 

--- a/lib/conduit/util.rb
+++ b/lib/conduit/util.rb
@@ -12,7 +12,7 @@ module Conduit
     rescue NameError => error
       message = "Unable to find driver with arguments: #{args.join ','}. " +
                 "Expected #{error.name} to be implemented"
-      raise NameError(message)
+      raise NameError.new(message)
     end
 
   end

--- a/lib/conduit/util.rb
+++ b/lib/conduit/util.rb
@@ -7,10 +7,10 @@ module Conduit
     # => Conduit::Driver::Fusion::Purchase
     #
     def self.find_driver(*args)
-      driver = args.map(&:to_s).map(&:classify).join('::')
+      driver = args.map(&:to_s).map(&:camelize).join('::')
       Conduit::Driver.const_get(driver)
-    rescue NameError
-      # TODO: Determine the best course of action for failure
+    rescue NameError => error
+      raise NameError("Unable to find driver with arguments: #{args.join ','}. Expected #{error.name} to be implemented")
     end
 
   end

--- a/lib/conduit/util.rb
+++ b/lib/conduit/util.rb
@@ -7,6 +7,11 @@ module Conduit
     # => Conduit::Driver::Fusion::Purchase
     #
     def self.find_driver(*args)
+      find_driver!(*args)
+    rescue NameError
+    end
+
+    def self.find_driver!(*args)
       driver = args.map(&:to_s).map(&:camelize).join('::')
       Conduit::Driver.const_get(driver)
     rescue NameError => error

--- a/lib/conduit/util.rb
+++ b/lib/conduit/util.rb
@@ -10,7 +10,9 @@ module Conduit
       driver = args.map(&:to_s).map(&:camelize).join('::')
       Conduit::Driver.const_get(driver)
     rescue NameError => error
-      raise NameError("Unable to find driver with arguments: #{args.join ','}. Expected #{error.name} to be implemented")
+      message = "Unable to find driver with arguments: #{args.join ','}. " +
+        "Expected #{error.name} to be implemented"
+      raise NameError(message)
     end
 
   end

--- a/lib/conduit/version.rb
+++ b/lib/conduit/version.rb
@@ -1,3 +1,3 @@
 module Conduit
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/spec/classes/util_spec.rb
+++ b/spec/classes/util_spec.rb
@@ -11,7 +11,7 @@ describe Conduit::Util do
 
     it 'should throw NameError if it driver not found' do
       lambda do
-        driver = Conduit::Util.find_driver(:not_really_there)
+        Conduit::Util.find_driver(:not_really_there)
       end.should raise_error(NameError)
     end
   end

--- a/spec/classes/util_spec.rb
+++ b/spec/classes/util_spec.rb
@@ -7,9 +7,16 @@ describe Conduit::Util do
       driver.should_not be_nil
     end
 
+    it 'should not throw exception for missing driver' do
+      driver = Conduit::Util.find_driver(:missing)
+      driver.should be_nil
+    end
+  end
+
+  describe 'find_driver!' do
     it 'should throw NameError if it driver not found' do
       lambda do
-        Conduit::Util.find_driver(:not_really_there)
+        Conduit::Util.find_driver!(:not_really_there)
       end.should raise_error(NameError)
     end
   end

--- a/spec/classes/util_spec.rb
+++ b/spec/classes/util_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 describe Conduit::Util do
-
   describe 'find_driver' do
-
     it 'should find MyDriver' do
       driver = Conduit::Util.find_driver(:my_driver)
       driver.should_not be_nil
@@ -15,5 +13,4 @@ describe Conduit::Util do
       end.should raise_error(NameError)
     end
   end
-
 end

--- a/spec/classes/util_spec.rb
+++ b/spec/classes/util_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Conduit::Util do
+
+  describe 'find_driver' do
+
+    it 'should find MyDriver' do
+      driver = Conduit::Util.find_driver(:my_driver)
+      driver.should_not be_nil
+    end
+
+    it 'should throw NameError if it driver not found' do
+      lambda do
+        driver = Conduit::Util.find_driver(:not_really_there)
+      end.should raise_error(NameError)
+    end
+  end
+
+end


### PR DESCRIPTION
I think this is more in line with what people would expect. I also changed it to raise an error because otherwise typical usage would simply have a nil reference which wasn't that easy to track down to here. 