### PR TITLE
Conduit::Storage::File.write should open files in binary mode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit (0.6.0)
+    conduit (0.6.2)
       activesupport
       aws-sdk
       excon

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  ruby:
+    version: 2.0.0-p195

--- a/lib/conduit/storage/file.rb
+++ b/lib/conduit/storage/file.rb
@@ -40,7 +40,7 @@ module Conduit
           full_path = storage_path.join(key)
           FileUtils.mkdir_p(::File.dirname(full_path))
 
-          ::File.open(full_path, 'w') do |f|
+          ::File.open(full_path, 'wb') do |f|
             f.write(content)
           end
         end

--- a/lib/conduit/version.rb
+++ b/lib/conduit/version.rb
@@ -1,3 +1,3 @@
 module Conduit
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end

--- a/spec/classes/core/action_spec.rb
+++ b/spec/classes/core/action_spec.rb
@@ -16,13 +16,13 @@ shared_examples_for Conduit::Core::Action do
 
     describe '.requirements' do
       it 'returns an array of required attributes' do
-        subject.class.requirements.should == %i(foo bar baz).to_set
+        subject.class.requirements.should == [:foo, :bar, :baz].to_set
       end
     end
 
     describe '.attributes' do
       it 'returns an array of known attributes' do
-        subject.class.requirements.should == %i(foo bar baz).to_set
+        subject.class.requirements.should == [:foo, :bar, :baz].to_set
       end
     end
   end

--- a/spec/classes/core/driver_spec.rb
+++ b/spec/classes/core/driver_spec.rb
@@ -5,31 +5,31 @@ shared_examples_for Conduit::Core::Driver do
   context 'without an instance' do
     describe '.credentials' do
       it 'returns an array of required credentials' do
-        subject.credentials.should == %i(username password).to_set
+        subject.credentials.should == [:username, :password].to_set
       end
     end
 
     describe '.actions' do
       it 'returns an array of known action' do
-        subject.actions.should == %i(foo).to_set
+        subject.actions.should == [:foo].to_set
       end
     end
 
     describe '.permitted_attributes' do
       it 'returns the union of required and optional attributes' do
-        subject.permitted_attributes.should == %i(subdomain mock).to_set
+        subject.permitted_attributes.should == [:subdomain, :mock].to_set
       end
     end
 
     describe 'required_attributes' do
       it 'should return only the required attributes' do
-        subject.required_attributes.should eql %i(subdomain).to_set
+        subject.required_attributes.should eql [:subdomain].to_set
       end
     end
 
     describe 'optional_attributes' do
       it 'should return only the optional attributes' do
-        subject.optional_attributes.should eql %i(mock).to_set
+        subject.optional_attributes.should eql [:mock].to_set
       end
     end
 

--- a/spec/classes/core/parser_spec.rb
+++ b/spec/classes/core/parser_spec.rb
@@ -16,7 +16,7 @@ shared_examples_for Conduit::Core::Parser do
   context 'with an instance' do
     describe '#attributes' do
       it 'returns an array of known attributes' do
-        subject.attributes.should == %i(foo bar baz).to_set
+        subject.attributes.should == [:foo, :bar, :baz].to_set
       end
 
       it 'defines a method for foo' do


### PR DESCRIPTION
By writing the files in binary mode we better preserve the data (e.g., base64 encoded files, etc) while also avoiding any encoding differences between the response data and underlying filesystem preferences.